### PR TITLE
Edit UI test + fix toast error message

### DIFF
--- a/client/src/pages/admin/CreateCategory.js
+++ b/client/src/pages/admin/CreateCategory.js
@@ -98,7 +98,7 @@ const CreateCategory = () => {
         toast.error(data.message);
       }
     } catch (error) {
-      toast.error("Something went wrong");
+      toast.error(error.response?.data?.message || "Something went wrong");
     }
   };
   return (

--- a/tests/admin_category_management.spec.cjs
+++ b/tests/admin_category_management.spec.cjs
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
+test.setTimeout(30000);
+
 test.describe('Category Management', () => {
+  test.use({ expect: { timeout: 10000 } });
+
   test.beforeEach(async ({ page }) => {
     await page.goto('http://localhost:3000/dashboard/admin/create-category');
     await page.getByPlaceholder('Email').fill('mongo@gmail.com');
@@ -16,8 +20,8 @@ test.describe('Category Management', () => {
     await expect(page.getByText('Category name is required')).toBeVisible();
   });
 
-  test('should create and then edit a category', async ({ page }) => {
-    // Create a new category
+  test('should create, edit and delete a category', async ({ page }) => {
+    // Step 1: Create a new category
     const testCategoryName = 'Test Category ' + Date.now(); // to make each category unique to make edit function work
 
     await page.getByTestId('category-input').click();
@@ -26,7 +30,7 @@ test.describe('Category Management', () => {
     
     await expect(page.getByText(`${testCategoryName} is created`)).toBeVisible();
     
-    // Edit category
+    // Step 2: Edit category
     const categoryRow = page.getByRole('row').filter({ hasText: testCategoryName });
     await categoryRow.getByRole('button', { name: 'Edit' }).click();
     
@@ -34,28 +38,19 @@ test.describe('Category Management', () => {
     await page.getByTestId('modal').getByTestId('category-input').click();
     await page.getByTestId('modal').getByTestId('category-input').fill(editedName);
     await page.getByTestId('modal').getByRole('button', { name: 'Submit' }).click();
+    await page.waitForTimeout(2000);
     
     await expect(page.getByRole('cell', { name: editedName })).toBeVisible();
     await expect(page.getByText(`${editedName} is updated`)).toBeVisible();
-  });
-  
-  test('should delete a category successfully', async ({ page }) => {
-    // Create a new category to make sure we have something to delete
-    const testCategoryName = 'Test Category ' + Date.now(); // unique name
-    
-    await page.getByTestId('category-input').click();
-    await page.getByTestId('category-input').fill(testCategoryName);
-    await page.getByRole('button', { name: 'Submit' }).click();
-    
-    await expect(page.getByText(`${testCategoryName} is created`)).toBeVisible();
-    
-    // Delete the category
-    const row = page.getByRole('row').filter({ hasText: testCategoryName });
-    const deleteButton = row.getByRole('button', { name: 'Delete' });
+
+    // Step 3: Delete the edited category
+    const editedRow = page.getByRole('row').filter({ hasText: editedName });
+    const deleteButton = editedRow.getByRole('button', { name: 'Delete' });
     
     await deleteButton.click();
+    await page.waitForTimeout(2000);
     await expect(page.getByText("Category Deleted Successfully")).toBeVisible();
     
-    await expect(page.getByRole('cell', { name: testCategoryName })).not.toBeVisible();
+    await expect(page.locator(`text="${editedName}"`)).not.toBeVisible();
   });
 });


### PR DESCRIPTION
- Since playwright tests run independently, I combined create, edit and delete category in one test. 
- I fixed the error message to show the right one, when a category with products attached to it cannot be deleted.